### PR TITLE
Reboot time out to 20 minutes, doc link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the Python test suite for Izuma Edge end-to-end tests. The library is designed to be used with
 the [pytest test framework](https://docs.pytest.org/en/latest/).
 
-For more information, please see the [public documentation](https://developer.pelion.com/docs/device-management-edge/latest/testing/end-to-end.html).
+For more information, please see the [public documentation](https://developer.izumanetworks.com/docs/device-management-edge/latest/testing/end-to-end.html).
 
 ## License
 

--- a/tests/test_device_attributes.py
+++ b/tests/test_device_attributes.py
@@ -22,7 +22,7 @@
 # to get device information e.g. device attributes like registration status.
 #
 # More details about device-directory API's:
-# https://developer.pelion.com/docs/device-management-api/device-directory/
+# https://developer.izumanetworks.com/docs/device-management-api/device-directory/
 # ----------------------------------------------------------------------------
 import logging
 import pytest

--- a/tests/test_device_attributes.py
+++ b/tests/test_device_attributes.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, Pelion and affiliates.
 # Copyright (c) 2022, Izuma Networks
+# Copyright (c) 2020-2021, Pelion and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_k8s_kubectl.py
+++ b/tests/test_k8s_kubectl.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, Pelion and affiliates.
 # Copyright (c) 2022, Izuma Networks
+# Copyright (c) 2020-2021, Pelion and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_lwm2m_resources.py
+++ b/tests/test_lwm2m_resources.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, Pelion and affiliates.
 # Copyright (c) 2022, Izuma Networks
+# Copyright (c) 2020-2021, Pelion and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,7 +19,7 @@
 
 # ----------------------------------------------------------------------------
 # This test file tests use Izuma connect API:
-# https://developer.pelion.com/docs/device-management-api/connect/
+# https://developer.izumanetworks.com/docs/device-management-api/connect/
 # to read and write resource values from/to device.
 # ----------------------------------------------------------------------------
 

--- a/tests/test_remote_terminal.py
+++ b/tests/test_remote_terminal.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, Pelion and affiliates.
 # Copyright (c) 2022, Izuma Networks
+# Copyright (c) 2020-2021, Pelion and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_remote_terminal.py
+++ b/tests/test_remote_terminal.py
@@ -24,7 +24,7 @@
 # part of the set.
 #
 # Information regarding remote terminal
-# https://developer.pelion.com/docs/device-management-edge/2.2/managing/gateway-terminal-service.html
+# https://developer.izumanetworks.com/docs/device-management-edge/2.2/managing/gateway-terminal-service.html
 # ----------------------------------------------------------------------------
 
 import logging

--- a/tests/test_websocket_notifications.py
+++ b/tests/test_websocket_notifications.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2022 Izuma Networks
+# Copyright (c) 2022, Izuma Networks
 # Copyright (c) 2020-2021, Pelion and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/test_websocket_notifications.py
+++ b/tests/test_websocket_notifications.py
@@ -20,7 +20,7 @@
 
 # ----------------------------------------------------------------------------
 # This test file tests use Izuma notifications API:
-# https://developer.pelion.com/docs/device-management-api/notifications/
+# https://developer.izumanetworks.com/docs/device-management-api/notifications/
 # to register websocket notification channel to receive notifications like:
 # registration, registration-update, resource notifications from device.
 # ----------------------------------------------------------------------------
@@ -58,7 +58,9 @@ def test_registration_update_notification(edge, cloud_api, websocket):
 
 
 def test_registration_notification(edge, cloud_api, websocket):
-    wait_time = 3 * 60
+    # Wait time needs to be quite long, with the LmP OSTree image verifications - boot time is long
+    # Measurement on RPI3B+ showed 15 minutes.
+    wait_time = 20 * 60
     resource = '/3/0/4'
     payload = {'method': 'POST', 'uri': resource}
 


### PR DESCRIPTION
The reboot takes a really long time, as the OSTree verifications on RPi3B+ at least seem to take 15 minutes.

```
Verifying content integrity of 1 commit objects...
fsck objects (19968/19968) [=============] 100%
OSTree repo intact
Checking contents of OSTree deployment at /rootfs/ostree/deploy/lmp/deploy/d4787cd8a6d15e42d35f33a7d0ee2707cd93d65c15f1327f41ac79b9c0d3527c.0
```
Both of those stages take 7 minutes (with the faster microSD-card).

Update docs links to Izuma web address.
