### PR TITLE
Upgrade aiohttp to 3.9.0, drop Python 3.7 from matrix

### DIFF
--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
         matrix:
             os: ["ubuntu-20.04", "ubuntu-22.04"]
-            python-ver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+            python-ver: ["3.8", "3.9", "3.10", "3.11"]
             exclude:
                 - os: ubuntu-22.04
                   python-ver: 3.6

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Izuma E2E Edge Python Test Suite Change log
 
+## 1.2.3
+- Updated `aiohttp` to 3.9.0 (from 3.8.6).
+
 ## 1.2.2
 - Fixed misspellings.
 - Updated `aiohttp` to 3.8.6 and `requests` to 2.31.0.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Jinja2==3.1.2
 pyyaml==6.0
 requests==2.31.0
 ws4py==0.5.1
-aiohttp==3.8.6
+aiohttp==3.9.0


### PR DESCRIPTION
* Update `aiohttp` due to a security issue in it.
* Drop Python 3.7 from installation test matrix due to `aiohttp` 3.9.0 not being available there anymore (Python 3.7 is End Of Life anyway), ref: https://endoflife.date/python


# Pull request template

Please fill this pull request template to describe your pull request.
If it introduces API breaks please describe it in detail.

## Check list

 ### Testing

 - [x] tests run against live device.

 ### Changelog
 
 - [x] `CHANGELOG.md` updated.

 ### Tagging
 
 - [ ] Remember to tag a new release, if need be.
